### PR TITLE
Add `SECURITY.md`

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+**Please do not disclose security-related issues publicly.**
+
+## Reporting a Vulnerability
+
+Please report potential security vulnerabilities to [matt@tighten.co](mailto:matt@tighten.co). All security vulnerabilities will be addressed promptly.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,4 +4,4 @@
 
 ## Reporting a Vulnerability
 
-Please report potential security vulnerabilities to [matt@tighten.co](mailto:matt@tighten.co). All security vulnerabilities will be addressed promptly.
+Report potential security vulnerabilities to [matt@tighten.co](mailto:matt@tighten.co). All security vulnerabilities will be addressed promptly.


### PR DESCRIPTION
This security policy will be used as the default for all Tighten repositories (public **and** private) that don't have their own. What that means is that it will be suggested in GitHub's UI when opening a new issue, and it will be displayed in the Security tab (beside Issues, Pull requests, etc). See [Creating a default community health file](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file).

Loosely based on [Laravel's](https://github.com/laravel/framework/security/policy) and [Spatie's](https://github.com/spatie/drupal-ray/security/policy). There isn't a ton to say really, but feel free to tweak the wording or suggest another email if Matt isn't the right person!